### PR TITLE
Fix the issue that empty tuple can't be a class member.

### DIFF
--- a/shiro/tuple/tuple.hpp
+++ b/shiro/tuple/tuple.hpp
@@ -318,6 +318,22 @@ class tuple {
   }
 };
 
+template <>
+class tuple<> {
+ public:
+  constexpr tuple() noexcept {}
+
+  constexpr tuple(const tuple&) noexcept = default;
+
+  constexpr tuple(tuple&&) noexcept = default;
+
+  tuple& operator=(const tuple&) noexcept = default;
+
+  tuple& operator=(tuple&&) noexcept = default;
+
+  void swap(tuple& t) noexcept {}
+};
+
 }  // namespace shiro
 
 #endif  // #ifndef SHIRO_TUPLE_TUPLE_HPP

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -20,6 +20,14 @@ constexpr bool apply_test_func(const char*, const char*, int, bool) {
   return true;
 }
 
+template<typename... Types>
+class member_test_class{
+  shiro::tuple<Types...> t;
+ public:
+  explicit constexpr member_test_class(Types&&... ts)
+      : t(std::forward<Types>(ts)...) {}
+};
+
 int main() {
   /* meta functions */
   {
@@ -404,5 +412,12 @@ int main() {
   {
     constexpr auto tmp = shiro::make_tuple("Hello", "world", 123, true);
     static_assert(shiro::apply(apply_test_func, tmp), "");
+  }
+
+  /* class member */
+  {
+    constexpr member_test_class<int, int, int> _1(1, 2, 3);
+    constexpr member_test_class<const char*, const char*> _2{"Hello", "world"};
+    constexpr member_test_class<> _3;
   }
 }


### PR DESCRIPTION
クラスメンバとして空のtupleを持ったクラスをデフォルトコンストラクトさせるとCEが発生します．
オーバーロード解決でデフォルトコンストラクタではなくUTypes&&...を受け取る方が優先され，条件チェック時にtuple_elementのstatic_assertでout of rangeとして弾かれるようです．

綺麗ではありませんが，ひとまず愚直な解決法として「templateパラメータが空の時のtupleを特殊化する」という方法で修正してみました．
ちなみにVeiler.TempleもSprout.Tupleも空の時は特殊化してます(Veilerについてはなんで特殊化したのかは覚えてないですが，なんかエラーが出て渋々，だったような気がします)．
そして少なくともその2つではこの問題は発生しておりませんので，ある意味実績のある(?)手法ではあるかと思います．